### PR TITLE
Convert Timestamp Block into a Dynamic Block

### DIFF
--- a/includes/blocks/timestamp-post/edit.js
+++ b/includes/blocks/timestamp-post/edit.js
@@ -1,32 +1,18 @@
 /**
  * WordPress dependencies.
  */
-import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Placeholder } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
-import apiFetch from '@wordpress/api-fetch';
 
 /**
  * Edit component.
  *
  * @see https://wordpress.org/gutenberg/handbook/designers-developers/developers/block-api/block-edit-save/#edit
  *
- * @param {object} props The block props.
  * @returns {Placeholder} The edit component.
  */
 
-const BlockEdit = (props) => {
-	const { setAttributes } = props;
-	const postId = useSelect((select) => select('core/editor').getCurrentPostId(), []);
-
-	useEffect(() => {
-		// Get the post meta.
-		apiFetch({ path: `/wp/v2/posts/${postId}` }).then((post) => {
-			setAttributes({ sdcomPreviousCertificateId: post.meta.sdcom_previous_certificate_id });
-		});
-	}, [postId, setAttributes]);
-
+const BlockEdit = () => {
 	return <Placeholder label={__('Timestamps', 'timestamps')} />;
 };
 

--- a/includes/blocks/timestamp-post/markup.php
+++ b/includes/blocks/timestamp-post/markup.php
@@ -7,7 +7,7 @@
 
 namespace SDCOM_Timestamps\Blocks\TimestampPost;
 
-$sdcom_previous_certificate_id = ! empty( $args['sdcomPreviousCertificateId'] ) ? $args['sdcomPreviousCertificateId'] : '';
+$sdcom_previous_certificate_id = get_post_meta( get_the_ID(), 'sdcom_previous_certificate_id', true );
 
 // Bail early if there is no embed_code.
 if ( empty( $sdcom_previous_certificate_id ) ) {

--- a/includes/blocks/timestamp-post/save.js
+++ b/includes/blocks/timestamp-post/save.js
@@ -1,11 +1,8 @@
-import { RawHTML } from '@wordpress/element';
-
-const BlockSave = ({ attributes }) => {
-	const { sdcomPreviousCertificateId } = attributes;
-
-	const embedCode = `<div class="sdcom-timestamps" data-id="${sdcomPreviousCertificateId}"></div>`;
-
-	return <RawHTML>{embedCode}</RawHTML>;
-};
+/**
+ * See https://wordpress.org/gutenberg/handbook/designers-developers/developers/block-api/block-edit-save/#save
+ *
+ * @returns {null} Dynamic blocks do not save the HTML.
+ */
+const BlockSave = () => null;
 
 export default BlockSave;

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -96,18 +96,22 @@ function is_block_editor_active() {
 
 	$classic_editor_replace = \get_option( 'classic-editor-replace' );
 
+	// We assume that the Block Editor is active, whilst the Classic Editor plugin never existed.
 	if ( empty( $classic_editor_replace ) ) {
-		return false;
+		return true;
 	}
 
+	// If the Classic Editor plugin is installed and activated, we check the setting.
 	if ( $classic_editor_replace === 'block' ) {
 		return true;
 	}
 
+	// If the Classic Editor plugin is installed and activated, we check the setting.
 	if ( $classic_editor_replace === 'classic' ) {
 		return false;
 	}
 
+	// We assume that the Block Editor is active by default.
 	return true;
 }
 


### PR DESCRIPTION
The timestamp block encounters intermittent issues with block validation due to the dynamic nature of saving posts via REST API.

Due to this, we are better off making it dynamic as it is a block that will change upon every post save.