### PR TITLE
Add GitHub Workflow: Push Releases to SVN Repository

### DIFF
--- a/.github/workflows/push-deploy.yml
+++ b/.github/workflows/push-deploy.yml
@@ -1,0 +1,25 @@
+name: Publish New Release
+
+env:
+  SLUG: "timestamps"
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  tag:
+    name: New release
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: WordPress Plugin Deploy
+      if: "! github.event.release.prerelease"
+      id: deploy
+      uses: 10up/action-wordpress-plugin-deploy@stable
+      env:
+        SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+        SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+        SLUG: ${{ env.SLUG }}


### PR DESCRIPTION
This allows tagged releases to be automatically pushed to the SVN repository.