### PR TITLE
Limit readme.txt file to 5 Tags

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === Timestamps – Blockchain Integration for WordPress ===
 Contributors: scoredetect, xmic
-Tags: timestamp, blockchain, content, authenticity, copyright, timestamps, protection, verification, proof, timestamping
+Tags: timestamp, blockchain, content, authenticity, copyright
 Requires at least: 6.0.0
 Tested up to: 6.6
 Requires PHP: 7.4


### PR DESCRIPTION
The WordPress plugin documentation has a limit of 5 tags.