### PR TITLE
Bulk Generate Timestamps Using WP-CLI

### DIFF
--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -1,0 +1,271 @@
+<?php
+/**
+ * WP-CLI command for SDCOM_Timestamps namespace.
+ *
+ * phpcs:disable WordPress.WP.I18n.MissingTranslatorsComment
+ *
+ * @since  1.8.0
+ * @package SDCOM_Timestamps
+ */
+
+namespace SDCOM_Timestamps;
+
+use WP_CLI_Command;
+use WP_CLI;
+use SDCOM_Timestamps\Command\Utility;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	// @codeCoverageIgnoreStart
+	exit; // Exit if accessed directly.
+	// @codeCoverageIgnoreEnd
+}
+
+/**
+ * CLI Commands for SDCOM_Timestamps namespace.
+ */
+class Command extends WP_CLI_Command {
+
+	/**
+	 * Holds temporary wp_actions when indexing with pagination.
+	 *
+	 * @since 1.8.0
+	 * @var  array
+	 */
+	private $temporary_wp_actions = [];
+
+	/**
+	 * Holds CLI command position args.
+	 *
+	 * Useful to share arguments to methods called by hooks.
+	 *
+	 * @since 1.8.0
+	 * @var array
+	 */
+	protected $args = [];
+
+	/**
+	 * Holds CLI command associative args.
+	 *
+	 * Useful to share arguments to methods called by hooks.
+	 *
+	 * @since 1.8.0
+	 * @var array
+	 */
+	protected $assoc_args = [];
+
+	/**
+	 * Internal timer.
+	 *
+	 * @since 1.8.0
+	 *
+	 * @var float
+	 */
+	protected $time_start = null;
+
+	/**
+	 * Holds the WP CLI progress bar.
+	 *
+	 * @var \WP_CLI\Progress\Bar
+	 */
+	public $progress_bar = null;
+
+	/**
+	 * Create Command.
+	 *
+	 * @since  1.8.0
+	 */
+	public function __construct() {}
+
+	/**
+	 * Generate timestamps for posts.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--force]
+	 * : Force the generation of timestamps without confirmation.
+	 *
+	 * [--post_type=<post_types>]
+	 * : Specify which post types will be used in the command (by default: only the `post` post type is used). For example, `--post_type="my_custom_post_type"` would limit to only posts from the post type "my_custom_post_type". Accepts multiple post types separated by comma.
+	 *
+	 * [--post_ids=<IDs>]
+	 * : Choose which post IDs to include in the command. For example, `--post_ids="1,2,3"` would limit to only posts with the IDs 1, 2, and 3. Accepts multiple post IDs separated by comma.
+	 *
+	 * [--post_status=<IDs>]
+	 * : Choose which post statuses to include in the command. For example, `--post_status="publish,draft"` would limit to only posts with the post status "publish" and "draft". Accepts multiple post statuses separated by comma.
+	 *
+	 * @since 1.8.0
+	 *
+	 * @param array $args Positional CLI args.
+	 * @param array $assoc_args Associative CLI args.
+	 *
+	 * @subcommand generate
+	 */
+	public function generate( $args, $assoc_args ) {
+		$post_type    = \WP_CLI\Utils\get_flag_value( $assoc_args, 'post_type', array( 'post' ) );
+		$post_ids     = \WP_CLI\Utils\get_flag_value( $assoc_args, 'post_ids', array() );
+		$post_status  = \WP_CLI\Utils\get_flag_value( $assoc_args, 'post_status', array( 'publish' ) );
+		$force_option = \WP_CLI\Utils\get_flag_value( $assoc_args, 'force', false );
+
+		if ( ! $force_option && empty( $post_ids ) ) {
+			WP_CLI::confirm( esc_html__( 'Are you sure you want to generate timestamps for all posts?', 'timestamps' ), $assoc_args );
+		}
+
+		/**
+		 * Fires before starting the command.
+		 *
+		 * Useful for deregistering filters/actions that occur during a query request.
+		 *
+		 * @hook timestamps_wp_cli_pre_generate
+		 * @param {array} $args Positional CLI args.
+		 * @param {array} $assoc_args Associative CLI args.
+		 *
+		 * @since 1.8.0
+		 */
+		do_action( 'timestamps_wp_cli_pre_generate', $args, $assoc_args );
+
+		Utility::timer_start();
+
+		// Defaults.
+		$index_args = array(
+			'post_type'   => $post_type,
+			'post_status' => $post_status,
+		);
+
+		// Post type.
+		if ( ! empty( $assoc_args['post_type'] ) ) {
+			$post_type = explode( ',', $assoc_args['post_type'] );
+			$post_type = array_map( 'trim', $post_type );
+
+			$index_args['post_type'] = $post_type;
+		}
+
+		// Post status.
+		if ( ! empty( $assoc_args['post_status'] ) ) {
+			$post_status = explode( ',', $assoc_args['post_status'] );
+			$post_status = array_map( 'trim', $post_status );
+
+			$index_args['post_status'] = $post_status;
+		}
+
+		// Post IDs.
+		if ( ! empty( $assoc_args['post_ids'] ) ) {
+			$post_ids = explode( ',', str_replace( ' ', '', $assoc_args['post_ids'] ) );
+			$post_ids = array_map( 'absint', $post_ids );
+
+			$index_args['post__in'] = $post_ids;
+		}
+
+		WP_CLI::line();
+
+		$query = new \WP_Query( $index_args );
+
+		$found_posts = $query->found_posts;
+
+		// Progress bar.
+		$this->progress_bar = WP_CLI\Utils\make_progress_bar(
+			sprintf( __( 'Generating timestamps for %d objects:', 'timestamps' ), $found_posts ),
+			$found_posts
+		);
+
+		// Loop through the posts in the query.
+		while ( $query->have_posts() ) {
+			$query->the_post();
+
+			// Generate timestamp for the post.
+			\SDCOM_Timestamps\TimestampHelper::factory()->generate_timestamp_for_post();
+
+			// Increment the progress bar.
+			$this->progress_bar->tick();
+
+            usleep( 500 );
+
+            // Avoid running out of memory.
+            $this->stop_the_insanity();
+		}
+
+		$sync_time_in_ms = Utility::timer_stop();
+
+		/**
+		 * Fires after executing the command.
+		 *
+		 * @hook timestamps_wp_cli_after_generate
+		 * @param {array} $args Positional CLI args.
+		 * @param {array} $assoc_args Associative CLI args.
+		 *
+		 * @since 1.8.0
+		 */
+		do_action( 'timestamps_wp_cli_after_generate', $args, $assoc_args );
+
+		WP_CLI::log( WP_CLI::colorize( '%Y' . esc_html__( 'Total time elapsed: ', 'timestamps' ) . '%N' . Utility::timer_format( $sync_time_in_ms ) ) );
+
+		WP_CLI::success( esc_html__( 'Done!', 'timestamps' ) );
+	}
+
+	/**
+	 * Resets some values to reduce memory footprint.
+     * 
+     * @since 1.8.0
+	 */
+	protected function stop_the_insanity() {
+		global $wpdb, $wp_object_cache, $wp_actions;
+
+		$wpdb->queries = [];
+
+		/*
+		 * Runtime flushing was introduced in WordPress 6.0 and will flush only the
+		 * in-memory cache for persistent object caches.
+		 */
+		if ( function_exists( 'wp_cache_flush_runtime' ) ) {
+			wp_cache_flush_runtime();
+		} else {
+
+			/*
+			 * In the case where we're not using an external object cache, we need to call flush on the default
+			 * WordPress object cache class to clear the values from the cache property.
+			 */
+			if ( ! wp_using_ext_object_cache() ) {
+				wp_cache_flush();
+			}
+		}
+
+		if ( is_object( $wp_object_cache ) ) {
+			$wp_object_cache->group_ops      = [];
+			$wp_object_cache->stats          = [];
+			$wp_object_cache->memcache_debug = [];
+
+			// Make sure this is a public property, before trying to clear it.
+			try {
+				$cache_property = new \ReflectionProperty( $wp_object_cache, 'cache' );
+				if ( $cache_property->isPublic() ) {
+					$wp_object_cache->cache = [];
+				}
+				unset( $cache_property );
+			} catch ( \ReflectionException $e ) {
+				// No need to catch.
+			}
+
+			if ( is_callable( $wp_object_cache, '__remoteset' ) ) {
+				call_user_func( [ $wp_object_cache, '__remoteset' ] );
+			}
+		}
+
+		// Prevent wp_actions from growing out of control.
+		// phpcs:disable
+		$wp_actions = $this->temporary_wp_actions;
+		// phpcs:enable
+
+        /*
+         * It's high memory consuming as WP_Query instance holds all query results inside itself
+         * and in theory $wp_filter will not stop growing until Out Of Memory exception occurs.
+         */
+		remove_filter( 'get_term_metadata', [ wp_metadata_lazyloader(), 'lazyload_term_meta' ] );
+
+		/**
+		 * Fires after reducing the memory footprint.
+		 *
+		 * @since 1.8.0
+		 * @hook timestamps_stop_the_insanity
+		 */
+		do_action( 'timestamps_stop_the_insanity' );
+	}
+}

--- a/includes/classes/Command.php
+++ b/includes/classes/Command.php
@@ -177,10 +177,10 @@ class Command extends WP_CLI_Command {
 			// Increment the progress bar.
 			$this->progress_bar->tick();
 
-            usleep( 500 );
+			usleep( 500 );
 
-            // Avoid running out of memory.
-            $this->stop_the_insanity();
+			// Avoid running out of memory.
+			$this->stop_the_insanity();
 		}
 
 		$sync_time_in_ms = Utility::timer_stop();
@@ -203,8 +203,8 @@ class Command extends WP_CLI_Command {
 
 	/**
 	 * Resets some values to reduce memory footprint.
-     * 
-     * @since 1.8.0
+	 *
+	 * @since 1.8.0
 	 */
 	protected function stop_the_insanity() {
 		global $wpdb, $wp_object_cache, $wp_actions;
@@ -254,10 +254,10 @@ class Command extends WP_CLI_Command {
 		$wp_actions = $this->temporary_wp_actions;
 		// phpcs:enable
 
-        /*
-         * It's high memory consuming as WP_Query instance holds all query results inside itself
-         * and in theory $wp_filter will not stop growing until Out Of Memory exception occurs.
-         */
+		/*
+		 * It's high memory consuming as WP_Query instance holds all query results inside itself
+		 * and in theory $wp_filter will not stop growing until Out Of Memory exception occurs.
+		 */
 		remove_filter( 'get_term_metadata', [ wp_metadata_lazyloader(), 'lazyload_term_meta' ] );
 
 		/**

--- a/includes/classes/Command/Utility.php
+++ b/includes/classes/Command/Utility.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * SDCOM_Timestamps CLI Utility
+ *
+ * @since 1.8.0
+ * @package SDCOM_Timestamps
+ */
+
+namespace SDCOM_Timestamps\Command;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Utility class for WP CLI commands.
+ */
+class Utility {
+
+	/**
+	 * Internal timer.
+	 *
+	 * @var float
+	 */
+	protected static $time_start = null;
+
+	/**
+	 * Stops the timer.
+	 *
+	 * @param int $precision The number of digits from the right of the decimal to display. Default 3.
+	 * @return float Time spent so far
+	 */
+	public static function timer_stop( $precision = 3 ) {
+		$diff = microtime( true ) - self::$time_start;
+		return (float) number_format( (float) $diff, $precision );
+	}
+
+	/**
+	 * Starts the timer.
+	 *
+	 * @return true
+	 */
+	public static function timer_start() {
+		self::$time_start = microtime( true );
+		return true;
+	}
+
+	/**
+	 * Given a timestamp in microseconds, returns it in the given format.
+	 *
+	 * @param float  $microtime Unix timestamp in ms
+	 * @param string $format    Desired format
+	 * @return string
+	 */
+	public static function timer_format( $microtime, $format = 'H:i:s.u' ) {
+		$microtime_date = \DateTime::createFromFormat( 'U.u', number_format( (float) $microtime, 3, '.', '' ) );
+		return $microtime_date->format( $format );
+	}
+}

--- a/includes/classes/TimestampHelper.php
+++ b/includes/classes/TimestampHelper.php
@@ -1,0 +1,345 @@
+<?php
+/**
+ * Timestamp Helper.
+ *
+ * @since 1.8.0
+ * @package SDCOM_Timestamps
+ */
+
+namespace SDCOM_Timestamps;
+
+/**
+ * Timestamp Helper Class.
+ *
+ * @since 1.8.0
+ */
+class TimestampHelper {
+
+	/**
+	 * Initialize class.
+	 *
+	 * @since 1.8.0
+	 */
+	public function setup() {}
+
+	/**
+	 * Generates the timestamp for a post.
+	 *
+	 * @since 1.8.0
+	 *
+	 * @param int|WP_Post|null $post Optional. Post ID or post object. `null`, `false`, `0` and other PHP falsey values
+	 *                               return the current global post inside the loop. A numerically valid post ID that
+	 *                               points to a non-existent post returns `null`. Defaults to global $post.
+	 * @return object|false          The data returned by the API on success, or false on failure.
+	 * @throws \Throwable            If an exception occurs during the process.
+	 * @throws \Exception            If the options, post content, or API key is empty.
+	 */
+	public function generate_timestamp_for_post( $post = null ) {
+
+		try {
+			$post = get_post( $post );
+
+			// Bail early if the post is empty.
+			if ( empty( $post ) ) {
+				return false;
+			}
+
+			$post_id = $post->ID;
+
+			update_post_meta( $post_id, 'sdcom_timestamp_post', true );
+
+			$create_certificate = $this->create_certificate_post( $post );
+
+			// Handle the case where the method returned false.
+			if ( $create_certificate === false ) {
+				throw new \Exception( 'Create certificate failed.' );
+			}
+
+			$certificate_id = ! empty( $create_certificate->{'certificate'}->{'id'} ) ? $create_certificate->{'certificate'}->{'id'} : '';
+
+			// Handle the case where the certificate id is empty.
+			if ( empty( $certificate_id ) ) {
+				throw new \Exception( 'Certificate id is empty.' );
+			}
+
+			$update_certificate = $this->update_certificate_post( $post, $certificate_id );
+
+			// Handle the case where the method returned false.
+			if ( $update_certificate === false ) {
+				throw new \Exception( 'Update certificate failed.' );
+			}
+
+			// Bail early if the certificate id is empty.
+			if ( empty( $certificate_id ) ) {
+				throw new \Exception( 'Certificate id is empty.' );
+			}
+
+			// Update the post meta with the new certificate id.
+			update_post_meta( $post_id, 'sdcom_previous_certificate_id', $certificate_id );
+
+			// Update the content to set the data-id to the new certificate id.
+			$pattern = '/<div class="sdcom-timestamps" data-id="(.*?)">.*<\/div>/';
+			if ( preg_match( $pattern, $post->post_content, $matches ) ) {
+				$current_certificate_id = $matches[1];
+
+				// Check if the current certificate id is not the new certificate id.
+				if ( $current_certificate_id !== $certificate_id ) {
+
+					// Update the post content to replace the previous certificate id.
+					$replacement = sprintf(
+						'<div class="sdcom-timestamps" data-id="%s"></div>',
+						esc_attr( $certificate_id )
+					);
+
+					$post->post_content = preg_replace( $pattern, $replacement, $post->post_content );
+
+					wp_update_post( $post );
+				}
+			}
+		} catch ( \Exception $e ) {
+			// Handle the exception.
+			error_log( 'An error occurred: ' . $e->getMessage() );
+		}
+	}
+
+	/**
+	 * Creates a certificate for a post.
+	 *
+	 * @since 1.8.0
+	 *
+	 * @param int|WP_Post|null $post Optional. Post ID or post object. `null`, `false`, `0` and other PHP falsey values
+	 *                               return the current global post inside the loop. A numerically valid post ID that
+	 *                               points to a non-existent post returns `null`. Defaults to global $post.
+	 * @return object|false The data returned by the API on success, or false on failure.
+	 * @throws \Throwable If an exception occurs during the process.
+	 * @throws \Exception If the options, post content, or API key is empty.
+	 */
+	private function create_certificate_post( $post = null ) {
+
+		try {
+			$post = get_post( $post );
+
+			// Bail early if the post is empty.
+			if ( empty( $post ) ) {
+				return false;
+			}
+
+			$post_id                       = $post->ID;
+			$post_content                  = $post->post_content;
+			$sdcom_timestamps              = get_option( SDCOM_TIMESTAMPS_OPTIONS );
+			$sdcom_previous_certificate_id = get_post_meta( $post_id, 'sdcom_previous_certificate_id', true );
+
+			// Bail early if the options are empty.
+			if ( empty( $sdcom_timestamps ) ) {
+				throw new \Exception( 'Options are empty.' );
+			}
+
+			// Bail early if the post content is empty.
+			if ( empty( $post_content ) ) {
+				throw new \Exception( 'Post content is empty.' );
+			}
+
+			$sdcom_timestamps_display_created_by = ! empty( $sdcom_timestamps['display_created_by'] ) ? $sdcom_timestamps['display_created_by'] : false;
+			$sdcom_timestamps_username           = 'anonymous';
+			$sdcom_timestamps_api_key            = ! empty( $sdcom_timestamps['api_key'] ) ? $sdcom_timestamps['api_key'] : '';
+
+			// Bail early if the api key is empty.
+			if ( empty( $sdcom_timestamps_api_key ) ) {
+				throw new \Exception( 'API key is empty.' );
+			}
+
+			if ( $sdcom_timestamps_display_created_by === 'true' ) {
+				$sdcom_timestamps_username = ! empty( $sdcom_timestamps['username'] ) ? $sdcom_timestamps['username'] : 'anonymous';
+			}
+
+			$url = 'https://api.scoredetect.com/create-certificate';
+
+			$metadata = array(
+				'certificateType'  => 'plain_text_upload',
+				'displayCreatedBy' => $sdcom_timestamps_display_created_by === 'true' ? true : false,
+				'username'         => $sdcom_timestamps_username,
+			);
+
+			$form_data = array(
+				'file'     => $post_content,
+				'username' => $metadata['username'],
+			);
+
+			if ( ! empty( $sdcom_previous_certificate_id ) ) {
+				$form_data['previous_certificate_id'] = $sdcom_previous_certificate_id;
+			}
+
+			$request = wp_remote_post(
+				$url,
+				array(
+					'timeout' => 30,
+					'headers' => array(
+						'Authorization' => 'Bearer ' . $sdcom_timestamps_api_key,
+					),
+					'body'    => $form_data,
+				)
+			);
+
+			if ( is_wp_error( $request ) ) {
+				throw new \Exception( 'WP Error' );
+			}
+
+			/**
+			 * Ensure we have a successful response code.
+			 */
+			if ( 200 !== wp_remote_retrieve_response_code( $request ) ) {
+				throw new \Exception( 'Response code is not 200' );
+			}
+
+			/**
+			 * Retrieve and parse the contents of the API response, which is JSON.
+			 */
+			$content = wp_remote_retrieve_body( $request );
+			$data    = json_decode( $content );
+
+			/**
+			 * Detect any issues with decoding the JSON string into a PHP object.
+			 */
+			if ( empty( $data ) ) {
+				throw new \Exception( 'Data is empty' );
+			}
+
+			// Return the data.
+			return $data;
+
+		} catch ( \Throwable $th ) {
+			throw $th;
+		}
+	}
+
+	/**
+	 * Updates a certificate for a post.
+	 *
+	 * @since 1.8.0
+	 *
+	 * @param int|WP_Post|null $post           Optional. Post ID or post object. `null`, `false`, `0` and other PHP falsey values
+	 *                                         return the current global post inside the loop. A numerically valid post ID that
+	 *                                         points to a non-existent post returns `null`. Defaults to global $post.
+	 * @param string           $certificate_id The id of the certificate to update.
+	 * @return object|false                    The data returned by the API on success, or false on failure.
+	 * @throws \Exception                      If the certificate id, options, post content, or API key is empty.
+	 * @throws \Throwable                      If an exception occurs during the process.
+	 */
+	private function update_certificate_post( $post = null, $certificate_id ) {
+		try {
+
+			$post = get_post( $post );
+
+			// Bail early if the post is empty.
+			if ( empty( $post ) ) {
+				return false;
+			}
+
+			$post_content     = $post->post_content;
+			$sdcom_timestamps = get_option( SDCOM_TIMESTAMPS_OPTIONS );
+
+			// Bail early if the certificate id is empty.
+			if ( empty( $certificate_id ) ) {
+				throw new \Exception( 'Certificate id is empty.' );
+			}
+
+			// Bail early if the options are empty.
+			if ( empty( $sdcom_timestamps ) ) {
+				throw new \Exception( 'Options are empty.' );
+			}
+
+			// Bail early if the post content is empty.
+			if ( empty( $post_content ) ) {
+				throw new \Exception( 'Post content is empty.' );
+			}
+
+			$sdcom_timestamps_display_created_by = ! empty( $sdcom_timestamps['display_created_by'] ) ? $sdcom_timestamps['display_created_by'] : false;
+			$sdcom_timestamps_username           = 'anonymous';
+			$sdcom_timestamps_api_key            = ! empty( $sdcom_timestamps['api_key'] ) ? $sdcom_timestamps['api_key'] : '';
+
+			// Bail early if the api key is empty.
+			if ( empty( $sdcom_timestamps_api_key ) ) {
+				throw new \Exception( 'API key is empty.' );
+			}
+
+			if ( $sdcom_timestamps_display_created_by === 'true' ) {
+				$sdcom_timestamps_username = ! empty( $sdcom_timestamps['username'] ) ? $sdcom_timestamps['username'] : $sdcom_timestamps_username;
+			}
+
+			$url = 'https://api.scoredetect.com/update-certificate';
+
+			$metadata = array(
+				'certificateType'  => 'plain_text_upload',
+				'displayCreatedBy' => $sdcom_timestamps_display_created_by === 'true' ? true : false,
+				'username'         => $sdcom_timestamps_username,
+			);
+
+			$body = wp_json_encode(
+				array(
+					'certificateId' => $certificate_id,
+					'metadata'      => $metadata,
+				)
+			);
+
+			$request = wp_remote_request(
+				$url,
+				array(
+					'method'  => 'PATCH',
+					'timeout' => 30,
+					'headers' => array(
+						'Authorization' => 'Bearer ' . $sdcom_timestamps_api_key,
+						'Content-Type'  => 'application/json',
+					),
+					'body'    => $body,
+				)
+			);
+
+			if ( is_wp_error( $request ) ) {
+				throw new \Exception( 'WP Error' );
+			}
+
+			/**
+			 * Ensure we have a successful response code.
+			 */
+			if ( 200 !== wp_remote_retrieve_response_code( $request ) ) {
+				throw new \Exception( 'Response code is not 200' );
+			}
+
+			/**
+			 * Retrieve and parse the contents of the API response, which is JSON.
+			 */
+			$content = wp_remote_retrieve_body( $request );
+			$data    = json_decode( $content );
+
+			/**
+			 * Detect any issues with decoding the JSON string into a PHP object.
+			 */
+			if ( empty( $data ) ) {
+				throw new \Exception( 'Data is empty' );
+			}
+
+			// Return the data.
+			return $data;
+
+		} catch ( \Throwable $th ) {
+			throw $th;
+		}
+	}
+
+	/**
+	 * Return singleton instance of class.
+	 *
+	 * @return self
+	 * @since 1.8.0
+	 */
+	public static function factory() {
+		static $instance = false;
+
+		if ( ! $instance ) {
+			$instance = new self();
+			$instance->setup();
+		}
+
+		return $instance;
+	}
+}

--- a/timestamps.php
+++ b/timestamps.php
@@ -122,7 +122,7 @@ require_once SDCOM_TIMESTAMPS_INC . 'blocks.php';
 Screen::factory();
 
 /**
- * WP CLI Commands
+ * WP CLI Commands.
  */
 if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	WP_CLI::add_command( 'timestamps', __NAMESPACE__ . '\Command' );

--- a/timestamps.php
+++ b/timestamps.php
@@ -25,6 +25,8 @@
 
 namespace SDCOM_Timestamps;
 
+use WP_CLI;
+
 // If this file is called directly, abort.
 if ( ! defined( 'WPINC' ) ) {
 	die;
@@ -118,6 +120,13 @@ require_once SDCOM_TIMESTAMPS_INC . 'blocks.php';
  * Setup screen.
  */
 Screen::factory();
+
+/**
+ * WP CLI Commands
+ */
+if ( defined( 'WP_CLI' ) && WP_CLI ) {
+	WP_CLI::add_command( 'timestamps', __NAMESPACE__ . '\Command' );
+}
 
 /**
  * Load text domain.


### PR DESCRIPTION
Closes https://github.com/scoredetect/timestamps/issues/41

Allows a shell user to use the WP-CLI to generate timestamps for posts, pages, and custom post types.

For example:

```sh
wp timestamps generate --post_type=post,page --post_status=publish,draft --post_ids=1,2,3,4
```

This will generate a new set of timestamps for the specified fields which will be run within the [WP_Query](https://developer.wordpress.org/reference/classes/wp_query/) class.

Supports any post type using the `--post_type` flag.

This only generates the timestamps in the back-end.

This allows the front-end approach to either be implemented as a shortcode, or a Gutenberg "Timestamps" block.