### PR TITLE
fix(Screenshot): allow shortcode script globally

### DIFF
--- a/includes/classes/Feature/Timestamp/Screenshot.php
+++ b/includes/classes/Feature/Timestamp/Screenshot.php
@@ -74,11 +74,6 @@ class Screenshot extends Feature {
 	 */
 	public function scripts() {
 
-		// Bail early if the shortcode is not present.
-		if ( ! has_shortcode( get_the_content(), $this->shortcode ) ) {
-			return;
-		}
-
 		wp_enqueue_script(
 			'timestamps-screenshot-shortcode',
 			SDCOM_TIMESTAMPS_URL . '/dist/js/timestamps-screenshot-shortcode.js',


### PR DESCRIPTION
Since the shortcode javascript requires to be run in different places, it is better for it to be globally accessible. Once loaded, it gets cached and is not a performance bottleneck when tested for Core Web Vitals.