### PR TITLE
Fix html2canvas Issue

### DIFF
--- a/assets/js/timestamps-screenshot-shortcode/index.js
+++ b/assets/js/timestamps-screenshot-shortcode/index.js
@@ -9,7 +9,7 @@ import { __, sprintf } from '@wordpress/i18n';
 /**
  * External dependencies.
  */
-import html2canvas from 'html2canvas';
+import html2canvas from 'html2canvas-pro';
 import jsPDF from 'jspdf'; // eslint-disable-line import/no-extraneous-dependencies
 import autoTable from 'jspdf-autotable'; // eslint-disable-line import/no-extraneous-dependencies
 import QRCode from 'easyqrcodejs'; // eslint-disable-line import/no-extraneous-dependencies

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@supabase/supabase-js": "^2.39.3",
         "easyqrcodejs": "^4.6.1",
-        "html2canvas": "^1.4.1",
+        "html2canvas-pro": "^1.5.8",
         "jspdf": "^2.5.1",
         "jspdf-autotable": "^3.8.2",
         "prop-types": "^15.7.2"
@@ -10185,12 +10185,25 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
       "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "optional": true,
       "dependencies": {
         "css-line-break": "^2.1.0",
         "text-segmentation": "^1.0.3"
       },
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/html2canvas-pro": {
+      "version": "1.5.8",
+      "resolved": "https://registry.npmjs.org/html2canvas-pro/-/html2canvas-pro-1.5.8.tgz",
+      "integrity": "sha512-bVGAU7IvhBwBlRAmX6QhekX8lsaxmYoF6zIwf/HNlHscjx+KN8jw/U4PQRYqeEVm9+m13hcS1l5ChJB9/e29Lw==",
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/htmlparser2": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@supabase/supabase-js": "^2.39.3",
     "easyqrcodejs": "^4.6.1",
     "html2canvas": "^1.4.1",
+    "html2canvas-pro": "^1.5.8",
     "jspdf": "^2.5.1",
     "jspdf-autotable": "^3.8.2",
     "prop-types": "^15.7.2"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
   "dependencies": {
     "@supabase/supabase-js": "^2.39.3",
     "easyqrcodejs": "^4.6.1",
-    "html2canvas": "^1.4.1",
     "html2canvas-pro": "^1.5.8",
     "jspdf": "^2.5.1",
     "jspdf-autotable": "^3.8.2",


### PR DESCRIPTION
Since html2canvas has not been updated in 3 years, there is a fork of it called html2canvas-pro which offers modern fixes.